### PR TITLE
Rpc player client (DO NOT ACCEPT THIS)

### DIFF
--- a/src/player/sample_player.cpp
+++ b/src/player/sample_player.cpp
@@ -647,30 +647,6 @@ SamplePlayer::checkPreprocess()
     this->setViewAction( new View_Tactical() );
 
     //
-    // check shoot chance
-    //
-
-    const ShootGenerator::Container & cont = ShootGenerator::instance().courses( wm );
-
-    // update
-    if ( !cont.empty() )
-    {
-        ShootGenerator::Container::const_iterator best_shoot
-            = std::min_element( cont.begin(),
-                                cont.end(),
-                                ShootGenerator::ScoreCmp() );
-        
-        if ( wm.gameMode().type() != GameMode::IndFreeKick_
-            && wm.time().stopped() == 0
-            && wm.self().isKickable()
-            && best_shoot != cont.end() )
-        {
-            return true;
-        }
-    }
-
-
-    //
     // check queued action
     //
     // if ( this->doIntention() )
@@ -794,15 +770,6 @@ SamplePlayer::doPreprocess()
 
     this->setViewAction( new View_Tactical() );
 
-    //
-    // check shoot chance
-    //
-    if ( doShoot() )
-    {
-        return true;
-    }
-
-    //
     // check queued action
     //
     // if ( this->doIntention() )

--- a/src/player/sample_player.h
+++ b/src/player/sample_player.h
@@ -115,6 +115,7 @@ protected:
 private:
 
     bool doPreprocess();
+    bool checkPreprocess();
     bool doShoot();
     bool doForceKick();
     bool doHeardPassReceive();

--- a/src/rpc-client/rpc-player-client.cpp
+++ b/src/rpc-client/rpc-player-client.cpp
@@ -1,0 +1,30 @@
+#include "rpc-client/rpc-player-client.h"
+
+
+RpcPlayerClient::GrpcClientPlayer()
+{
+    M_agent_type = protos::AgentType::PlayerT;
+}
+
+void
+RpcPlayerClient::init(rcsc::PlayerAgent *agent,
+                            std::string target,
+                            int port,
+                            bool use_same_grpc_port,
+                            bool add_20_to_grpc_port_if_right_side)
+{
+    M_agent = agent;
+    M_unum = agent->world().self().unum();
+    M_team_name = agent->world().ourTeamName();
+    if (add_20_to_grpc_port_if_right_side)
+        if (M_agent->world().ourSide() == rcsc::SideID::RIGHT)
+            port += 20;
+
+    if (!use_same_grpc_port)
+    {
+        port += M_agent->world().self().unum();
+    }
+
+    this->M_target = target + ":" + std::to_string(port);
+    sample_communication = Communication::Ptr(new SampleCommunication());
+}

--- a/src/rpc-client/rpc-player-client.h
+++ b/src/rpc-client/rpc-player-client.h
@@ -1,0 +1,21 @@
+#ifndef RPC_PLAYER_CLIENT_H
+#define RPC_PLAYER_CLIENT_H
+
+#include "player/sample_communication.h"
+#include "rpc-client/rpc-client.h"
+
+class RpcPlayerClient : public IRpcClient {
+    rcsc::PlayerAgent * M_agent;
+    Communication::Ptr sample_communication;
+    public:
+    GrpcClientPlayer();
+
+    void init(rcsc::PlayerAgent * agent,
+              std::string target="localhost",
+              int port=50051,
+              bool use_same_grpc_port=true,
+              bool add_20_to_grpc_port_if_right_side=false);
+};
+
+
+#endif


### PR DESCRIPTION
این که یه کلاس بذاریم که یه سری تابع ها مثل do_preprocess یا init و بذاریم داخلش که thriftClientPlayer و grpcClientPlayer ازش به ارث ببرن نمیشه. دلیلش هم میتونی توی این pr ببینی.
یونیفرم نامبر و اسم تیم یه سری چیزای دیگه توی GrpcClient و ThriftClient تعریف شدن و اون کلاس ها هم نیاز دارن به این مقادیر
به نظرم تابع های do_preprocess رو جداگانه تو هر کلاس تعریف کنیم یا اینکه ساختار ارث بری رو باید یکم عوض کنیم.