### PR TITLE
Develop issues

### DIFF
--- a/src/grpc-client/state_generator.cpp
+++ b/src/grpc-client/state_generator.cpp
@@ -428,7 +428,7 @@ protos::GameModeType StateGenerator::converGameMode(const rcsc::GameMode::Type g
  */
 protos::WorldModel *StateGenerator::convertWorldModel(const rcsc::WorldModel &wm)
 {
-    auto *res = new WorldModel();
+    auto *res = new protos::WorldModel();
     res->set_allocated_intercept_table(convertInterceptTable(wm.interceptTable()));
     res->set_allocated_our_team_name(new std::string(wm.ourTeamName()));
     res->set_allocated_their_team_name(new std::string(wm.theirTeamName()));
@@ -438,11 +438,17 @@ protos::WorldModel *StateGenerator::convertWorldModel(const rcsc::WorldModel &wm
     res->set_allocated_ball(convertBall(wm.ball()));
     for (auto player : wm.teammates())
     {
+        if(player == nullptr || !player->posValid() || player->unum() < 1 || player->unum() > 11 ){
+            continue;
+        }
         auto p = res->add_teammates();
         updatePlayerObject(p, player);
     }
     for (auto player : wm.opponents())
     {
+        if(player == nullptr || !player->posValid() || player->unum() < 1 || player->unum() > 11 ){
+            continue;
+        }
         auto p = res->add_opponents();
         updatePlayerObject(p, player);
     }

--- a/src/grpc-client/state_generator.cpp
+++ b/src/grpc-client/state_generator.cpp
@@ -428,7 +428,7 @@ protos::GameModeType StateGenerator::converGameMode(const rcsc::GameMode::Type g
  */
 protos::WorldModel *StateGenerator::convertWorldModel(const rcsc::WorldModel &wm)
 {
-    auto *res = new protos::WorldModel();
+    auto *res = new WorldModel();
     res->set_allocated_intercept_table(convertInterceptTable(wm.interceptTable()));
     res->set_allocated_our_team_name(new std::string(wm.ourTeamName()));
     res->set_allocated_their_team_name(new std::string(wm.theirTeamName()));

--- a/src/thrift-client/thrift_state_generator.cpp
+++ b/src/thrift-client/thrift_state_generator.cpp
@@ -466,13 +466,21 @@ soccer::WorldModel ThriftStateGenerator::convertWorldModel(const rcsc::WorldMode
     res.ball = convertBall(wm.ball());
     for (auto player : wm.teammates())
     {
+        if(player == nullptr || !player->posValid() || player->unum() < 1 || player->unum() > 11 ){
+            continue;
+        }
         auto p = soccer::Player();
         updatePlayerObject(p, player);
+        res.teammates.push_back(p);
     }
     for (auto player : wm.opponents())
     {
+        if(player == nullptr || !player->posValid() || player->unum() < 1 || player->unum() > 11 ){
+            continue;
+        }
         auto p = soccer::Player();
         updatePlayerObject(p, player);
+        res.opponents.push_back(p);
     }
     // unknowns
     int counter = -1;


### PR DESCRIPTION
Added similar checks for invalid player objects in the `convertWorldModel` method, ensuring only valid players are added to the `teammates` and `opponents` lists.and teammeate 